### PR TITLE
Fix Unrestricted File Upload

### DIFF
--- a/upload.php
+++ b/upload.php
@@ -7,13 +7,27 @@ if (!isset($_SESSION['user_id'])) {
 }
 
 if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_FILES['image'])) {
-    $filename = 'uploads/' . basename($_FILES['image']['name']);
-    if (move_uploaded_file($_FILES['image']['tmp_name'], $filename)) {
-        $stmt = $pdo->prepare("INSERT INTO images (user_id, filename) VALUES (?, ?)");
-        $stmt->execute([$_SESSION['user_id'], $filename]);
-        echo "Immagine caricata con successo!";
+
+    // Generate a unique, random filename to avoid collisions and predictable names
+    $filename = uniqid() . '_' .  basename($_FILES['image']['name']);
+    $destination = 'uploads/' . $filename;
+
+    // Get the file extension
+    $ext = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
+
+    // Allow only specific image file types
+    $allowed_extensions = ['jpg', 'jpeg', 'png', 'gif'];
+
+    if (in_array($ext, $allowed_extensions)) {
+        if (move_uploaded_file($_FILES['image']['tmp_name'], $destination)) {
+            $stmt = $pdo->prepare("INSERT INTO images (user_id, filename) VALUES (?, ?)");
+            $stmt->execute([$_SESSION['user_id'], $filename]);
+            echo "Immagine caricata con successo!";
+        } else {
+            echo "Errore nel caricamento dell'immagine.";
+        }
     } else {
-        echo "Errore nel caricamento dell'immagine.";
+        echo "Tipo di file non consentito.";
     }
 }
 ?>


### PR DESCRIPTION
Fix Unrestricted File Upload vulnerability.
Note that this code change alone might not be enough because (at least):
 - another php script (`index.php`) shows all upload filenames
 - in some situations, php code can be injected into "seemingly legit" images (e.g. see [this](https://www.synacktiv.com/en/publications/persistent-php-payloads-in-pngs-how-to-inject-php-code-in-an-image-and-keep-it-there))

My suggestion is to prevent php execution in any folder but the root one. Note that how to do this depends on the web server used.